### PR TITLE
Add autoload paths.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,9 @@ module Importr
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.autoload_paths += %W(#{config.root}/lib)
+    config.autoload_paths += Dir["#{config.root}/lib/*/"]
+    config.eager_load = true
+    config.eager_load_paths += %W(#{config.root}/lib)
   end
 end


### PR DESCRIPTION
Fix `TroysAPIClient` autoload after Rails 6 update.